### PR TITLE
Add GOST key enum and macro utilities

### DIFF
--- a/lib/cryptohi/keythi.h
+++ b/lib/cryptohi/keythi.h
@@ -38,6 +38,7 @@ typedef enum {
     kyberKey = 9,
     edKey = 10,
     ecMontKey = 11,
+    gostKey = 12,
 } KeyType;
 
 /*
@@ -136,6 +137,17 @@ struct SECKEYECPublicKeyStr {
 typedef struct SECKEYECPublicKeyStr SECKEYECPublicKey;
 
 /*
+** GOST EC Public Key structure
+*/
+struct SECKEYGOSTPublicKeyStr {
+    SECItem value;        /* public EC point (x,y) */
+    SECItem params;       /* EC parameter OID */
+    SECItem digestParams; /* digest algorithm OID */
+    SECItem encryptParams;/* encryption parameter OID */
+};
+typedef struct SECKEYGOSTPublicKeyStr SECKEYGOSTPublicKey;
+
+/*
 ** FORTEZZA Public Key structures
 */
 struct SECKEYFortezzaPublicKeyStr {
@@ -203,6 +215,7 @@ struct SECKEYPublicKeyStr {
         SECKEYKEAPublicKey kea;
         SECKEYFortezzaPublicKey fortezza;
         SECKEYECPublicKey ec;
+        SECKEYGOSTPublicKey gost;
         SECKEYKyberPublicKey kyber;
     } u;
 };

--- a/lib/softoken/lowkeyti.h
+++ b/lib/softoken/lowkeyti.h
@@ -10,6 +10,7 @@
 #include "secitem.h"
 #include "secasn1t.h"
 #include "secoidt.h"
+#include "keythi.h"
 
 /*
 ** Typedef for callback to get a password "key".
@@ -62,7 +63,8 @@ typedef enum {
     NSSLOWKEYRSAKey = 1,
     NSSLOWKEYDSAKey = 2,
     NSSLOWKEYDHKey = 4,
-    NSSLOWKEYECKey = 5
+    NSSLOWKEYECKey = 5,
+    NSSLOWKEYGOSTKey = 6
 } NSSLOWKEYType;
 
 /*
@@ -76,6 +78,7 @@ struct NSSLOWKEYPublicKeyStr {
         DSAPublicKey dsa;
         DHPublicKey dh;
         ECPublicKey ec;
+        SECKEYGOSTPublicKey gost;
     } u;
 };
 typedef struct NSSLOWKEYPublicKeyStr NSSLOWKEYPublicKey;

--- a/lib/util/seccomon.h
+++ b/lib/util/seccomon.h
@@ -26,6 +26,9 @@
 
 #include "secport.h"
 
+/* Convert bit length to octet length */
+#define BITLEN_TO_OCTETLEN(bitLen) (((bitLen) + 7) >> 3)
+
 typedef enum {
     siBuffer = 0,
     siClearDataBuffer = 1,

--- a/lib/util/secdert.h
+++ b/lib/util/secdert.h
@@ -121,9 +121,9 @@ struct DERTemplateStr {
 ** Macro to convert der decoded bit string into a decoded octet
 ** string. All it needs to do is fiddle with the length code.
 */
-#define DER_ConvertBitString(item)            \
-    {                                         \
-        (item)->len = ((item)->len + 7) >> 3; \
+#define DER_ConvertBitString(item)                     \
+    {                                                  \
+        (item)->len = BITLEN_TO_OCTETLEN((item)->len); \
     }
 
 #endif /* _SECDERT_H_ */


### PR DESCRIPTION
## Summary
- provide `BITLEN_TO_OCTETLEN` macro
- use macro in `DER_ConvertBitString`
- extend key type enums and structures with GOST support
- include GOST fields in public key structures

## Testing
- `./build.sh -c` *(fails: `../configure` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68850a5278c8832e9272c540da45aa90