### PR TITLE
Implement SECITEM_CopyData and export

### DIFF
--- a/lib/nss/nss.def
+++ b/lib/nss/nss.def
@@ -125,6 +125,7 @@ PORT_SetUCS4_UTF8ConversionFunction;
 PORT_SetUCS2_UTF8ConversionFunction;
 PORT_SetUCS2_ASCIIConversionFunction;
 SECITEM_CopyItem;
+SECITEM_CopyData;
 SECITEM_DupItem;
 SECITEM_FreeItem;
 SECITEM_ZfreeItem;

--- a/lib/nss/utilwrap.c
+++ b/lib/nss/utilwrap.c
@@ -110,6 +110,7 @@
 #undef SECITEM_ArenaDupItem
 #undef SECITEM_CompareItem
 #undef SECITEM_CopyItem
+#undef SECITEM_CopyData
 #undef SECITEM_DupItem
 #undef SECITEM_FreeItem
 #undef SECITEM_ItemsAreEqual
@@ -377,6 +378,14 @@ SECITEM_CopyItem(PLArenaPool *arena, SECItem *to,
                  const SECItem *from)
 {
     return SECITEM_CopyItem_Util(arena, to, from);
+}
+
+SECStatus
+SECITEM_CopyData(PLArenaPool *arena, SECItem *to,
+                 SECItemType type, const unsigned char *data,
+                 unsigned int len)
+{
+    return SECITEM_CopyData_Util(arena, to, type, data, len);
 }
 
 SECItem *

--- a/lib/util/nssutil.def
+++ b/lib/util/nssutil.def
@@ -213,6 +213,7 @@ UTIL_SetForkState;
 ;+    global:
 NSS_SecureMemcmp;
 PORT_LoadLibraryFromOrigin;
+SECITEM_CopyData_Util;
 ;+    local:
 ;+       *;
 ;+};

--- a/lib/util/secitem.c
+++ b/lib/util/secitem.c
@@ -281,6 +281,31 @@ SECITEM_CopyItem(PLArenaPool *arena, SECItem *to, const SECItem *from)
     return SECSuccess;
 }
 
+SECStatus
+SECITEM_CopyData(PLArenaPool *arena, SECItem *to,
+                 SECItemType type, const unsigned char *data,
+                 unsigned int len)
+{
+    to->type = type;
+    if (data && len) {
+        if (arena) {
+            to->data = (unsigned char *)PORT_ArenaAlloc(arena, len);
+        } else {
+            to->data = (unsigned char *)PORT_Alloc(len);
+        }
+
+        if (!to->data) {
+            return SECFailure;
+        }
+        PORT_Memcpy(to->data, data, len);
+        to->len = len;
+    } else {
+        to->data = NULL;
+        to->len = 0;
+    }
+    return SECSuccess;
+}
+
 void
 SECITEM_FreeItem(SECItem *zap, PRBool freeit)
 {

--- a/lib/util/secitem.h
+++ b/lib/util/secitem.h
@@ -86,6 +86,11 @@ extern PRBool SECITEM_ItemsAreEqual(const SECItem *a, const SECItem *b);
 */
 extern SECStatus SECITEM_CopyItem(PLArenaPool *arena, SECItem *to,
                                   const SECItem *from);
+/* Copy data of given type and length into SECItem */
+extern SECStatus SECITEM_CopyData(PLArenaPool *arena, SECItem *to,
+                                  SECItemType type,
+                                  const unsigned char *data,
+                                  unsigned int len);
 
 /*
 ** Allocate an item and copy "from" into it.

--- a/lib/util/utilrename.h
+++ b/lib/util/utilrename.h
@@ -104,6 +104,7 @@
 #define SECITEM_ArenaDupItem SECITEM_ArenaDupItem_Util
 #define SECITEM_CompareItem SECITEM_CompareItem_Util
 #define SECITEM_CopyItem SECITEM_CopyItem_Util
+#define SECITEM_CopyData SECITEM_CopyData_Util
 #define SECITEM_DupItem SECITEM_DupItem_Util
 #define SECITEM_FreeItem SECITEM_FreeItem_Util
 #define SECITEM_ItemsAreEqual SECITEM_ItemsAreEqual_Util


### PR DESCRIPTION
## Summary
- add SECITEM_CopyData implementation in `secitem.c`
- expose SECITEM_CopyData in headers and util rename
- export symbol from `nss.def` and `nssutil.def`
- wrap SECITEM_CopyData in `utilwrap.c`

## Testing
- `./build.sh --help`
- `make nss_build_all` *(fails: No rule to make target '../nspr/configure', needed by '../nspr/Linux6.12_x86_cc_glibc_PTH_DBG.OBJ/config.status')*

------
https://chatgpt.com/codex/tasks/task_e_68850c13f4e4832eba84986f5d457953