### PR TITLE
Add --enable-gost support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,6 +125,7 @@ while [ $# -gt 0 ]; do
         --system-nspr) set_nspr_path "/usr/include/nspr/:"; no_local_nspr=1 ;;
         --system-sqlite) gyp_params+=(-Duse_system_sqlite=1) ;;
         --enable-fips) gyp_params+=(-Ddisable_fips=0) ;;
+        --enable-gost) gyp_params+=(-Ddisable_gost=0) ;;
         --fips-module-id) gyp_params+=(-Dfips_module_id="$2"); shift ;;
         --fips-module-id=?*) gyp_params+=(-Dfips_module_id="${1#*=}") ;;
         --enable-libpkix) gyp_params+=(-Ddisable_libpkix=0) ;;

--- a/coreconf/config.gypi
+++ b/coreconf/config.gypi
@@ -136,6 +136,7 @@
     'nss_include_dir%': '/usr/include/nss',
     'only_dev_random%': 1,
     'disable_fips%': 1,
+    'disable_gost%': 1,
     'fips_module_id%': '',
     'mozpkix_only%': 0,
     'mozilla_central%': 0,
@@ -175,6 +176,11 @@
         'defines': [
           'NSS_FIPS_DISABLED',
           'NSS_NO_INIT_SUPPORT',
+        ],
+      }],
+      [ 'disable_gost==0', {
+        'defines': [
+          'NSS_ENABLE_GOST',
         ],
       }],
       [ 'fips_module_id!=""', {

--- a/help.txt
+++ b/help.txt
@@ -5,7 +5,8 @@ Usage: build.sh [-h] [-c|-cc] [-v] [-j <n>] [--gyp|-g] [--opt|-o]
                 [--fuzz[=tls|oss]] [--sancov[=edge|bb|func|...]]
                 [--emit-llvm] [--no-zdefs] [--static] [--ct-verif]
                 [--nspr|--with-nspr=<include>:<lib>|--system-nspr]
-                [--system-sqlite] [--enable-fips] [--enable-libpkix]
+                [--system-sqlite] [--enable-fips] [--enable-gost]
+                [--enable-libpkix]
                 [--mozpkix-only] [-D<gyp-option>]
                 [--rebuild] [--enable-legacy-db]
 
@@ -53,6 +54,7 @@ NSS build tool options:
                      shorthand for --with-nspr=/usr/include/nspr:
     --system-sqlite  use system sqlite
     --enable-fips    enable FIPS checks
+    --enable-gost    enable GOST algorithms
     --enable-libpkix make libpkix part of the build
     --enable-legacy-db enable the legacy db (libnssdbm)
     --mozpkix-only   build only static mozpkix and mozpkix-test libraries


### PR DESCRIPTION
## Summary
- add `--enable-gost` switch in build.sh
- document new option in help.txt
- allow gyp variable `disable_gost` with default of 1
- define `NSS_ENABLE_GOST` when GOST is enabled
- attempted to regenerate build files

## Testing
- `./build.sh -h | head -n 5`
- `./build.sh --rebuild 2>&1 | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_688527743aa4832e92da91d7f09beffb